### PR TITLE
Replace tsToOrigin/floatBusAdjust with single ulaTsToDisplay origin

### DIFF
--- a/src/machines/contention.cpp
+++ b/src/machines/contention.cpp
@@ -14,7 +14,7 @@ void ULAContention::init(const MachineInfo& info)
 {
     tsPerFrame_ = info.tsPerFrame;
     tsPerScanline_ = info.tsPerLine;
-    tsToOrigin_ = info.tsToOrigin;
+    cpuTsToContention_ = info.ulaTsToDisplay - 1;  // contention starts 1 T-state before ULA fetch
     altContention_ = info.altContention;
     buildContentionTable();
 }
@@ -26,10 +26,10 @@ void ULAContention::buildContentionTable()
         memoryContentionTable_[i] = 0;
         ioContentionTable_[i] = 0;
 
-        if (i >= tsToOrigin_)
+        if (i >= cpuTsToContention_)
         {
-            uint32_t line = (i - tsToOrigin_) / tsPerScanline_;
-            uint32_t ts = (i - tsToOrigin_) % tsPerScanline_;
+            uint32_t line = (i - cpuTsToContention_) / tsPerScanline_;
+            uint32_t ts = (i - cpuTsToContention_) % tsPerScanline_;
 
             if (line < SCREEN_HEIGHT && ts < TS_HORIZONTAL_DISPLAY)
             {

--- a/src/machines/contention.hpp
+++ b/src/machines/contention.hpp
@@ -28,7 +28,7 @@ private:
 
     uint32_t tsPerFrame_ = 0;
     uint32_t tsPerScanline_ = 0;
-    uint32_t tsToOrigin_ = 0;
+    uint32_t cpuTsToContention_ = 0;
     bool altContention_ = false;
 
     uint32_t memoryContentionTable_[MAX_TSTATES_PER_FRAME + 1]{};

--- a/src/machines/display.hpp
+++ b/src/machines/display.hpp
@@ -29,7 +29,7 @@ public:
 
     uint32_t getCurrentDisplayTs() const { return currentDisplayTs_; }
 
-    uint8_t floatingBus(uint32_t cpuTStates, const uint8_t* memory, int32_t floatBusAdjust) const;
+    uint8_t floatingBus(uint32_t cpuTStates, const uint8_t* memory) const;
 
 private:
     void buildTsTable();
@@ -47,6 +47,8 @@ private:
     uint32_t paperStartLine_ = 0;
     uint32_t borderDrawingOffset_ = 0;
     uint32_t paperDrawingOffset_ = 0;
+    uint32_t ulaTsToDisplay_ = 0;
+    uint32_t tsPerFrame_ = 0;
 
     // Display lookup tables (sized for max machine variant)
     uint32_t tstateTable_[MAX_SCANLINES][MAX_TS_PER_LINE]{};

--- a/src/machines/machine_info.hpp
+++ b/src/machines/machine_info.hpp
@@ -24,7 +24,7 @@ enum MachineType {
 struct MachineInfo {
     uint32_t    intLength;
     uint32_t    tsPerFrame;
-    uint32_t    tsToOrigin;
+    uint32_t    ulaTsToDisplay;
     uint32_t    tsPerLine;
     uint32_t    tsTopBorder;
     uint32_t    tsVerticalBlank;
@@ -44,18 +44,17 @@ struct MachineInfo {
     uint32_t    paperDrawingOffset;
     uint32_t    romSize;
     uint32_t    ramSize;
-    int32_t     floatBusAdjust;
     bool        altContention;
     const char* machineName;
     uint32_t    machineType;
 };
 
-//                                int  tsPF   tsOr  tsLn  tsTB   tsVB  tsVD   tsHD  tsC pVB pVBl pHD  pVD  pHT  pVT  pEB  AY     Pg     bDO pDO romSz   ramSz    fbA  altC  name                        type
+//                                int  tsPF   ulaTD tsLn  tsTB   tsVB  tsVD   tsHD  tsC pVB pVBl pHD  pVD  pHT  pVT  pEB  AY     Pg     bDO pDO romSz   ramSz  altC  name                        type
 static const MachineInfo machines[] = {
-    { 32, 69888, 14335, 224, 12544, 1792, 43008, 128, 4, 56, 8, 256, 192, 448, 312, 32, false, false, 10, 16, 16384,  65536, -1, false, "ZX Spectrum 48K",      eZXSpectrum48 },
-    { 36, 70908, 14361, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 32768, 131072,  1, false, "ZX Spectrum 128K",     eZXSpectrum128 },
-    { 36, 70908, 14361, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 32768, 131072,  1, false, "ZX Spectrum 128K +2",  eZXSpectrum128_2 },
-    { 32, 70908, 14364, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 65536, 131072,  1,  true, "ZX Spectrum 128K +2A", eZXSpectrum128_2A },
+    { 32, 69888, 14336, 224, 12544, 1792, 43008, 128, 4, 56, 8, 256, 192, 448, 312, 32, false, false, 10, 16, 16384,  65536, false, "ZX Spectrum 48K",      eZXSpectrum48 },
+    { 36, 70908, 14362, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 32768, 131072, false, "ZX Spectrum 128K",     eZXSpectrum128 },
+    { 36, 70908, 14362, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 32768, 131072, false, "ZX Spectrum 128K +2",  eZXSpectrum128_2 },
+    { 32, 70908, 14365, 228, 12768, 1596, 43776, 128, 4, 56, 7, 256, 192, 448, 311, 32,  true,  true, 12, 16, 65536, 131072,  true, "ZX Spectrum 128K +2A", eZXSpectrum128_2A },
 };
 
 // Maximum sizes for shared arrays (accommodate all machine variants)

--- a/src/machines/zx48k/zx_spectrum_48k.cpp
+++ b/src/machines/zx48k/zx_spectrum_48k.cpp
@@ -202,7 +202,7 @@ uint8_t ZXSpectrum48::coreIORead(uint16_t address)
     }
 
     // Return floating bus value
-    return display_.floatingBus(z80_->getTStates(), pageRead_[1], machineInfo_.floatBusAdjust);
+    return display_.floatingBus(z80_->getTStates(), pageRead_[1]);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Introduce `ulaTsToDisplay` as the single source-of-truth timing constant representing when the ULA starts fetching display data (matching FUSE's `top_left_pixel`)
- Derive contention start (`cpuTsToContention`) as `ulaTsToDisplay - 1`, making the CPU/ULA timing relationship explicit in code
- Remove the per-machine `floatBusAdjust` fudge factor by rewriting `floatingBus()` to use origin subtraction (same structural approach as contention)

## Test plan
- [ ] `npm run build:wasm` compiles cleanly
- [ ] Test floating-bus-dependent software (Arkanoid, Cobra) for correct behaviour
- [ ] Verify contention timing unchanged (rename only, derived value matches previous `tsToOrigin`)