### PR TITLE
Add TAP file editor window

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -437,6 +437,13 @@
                             </button>
                             <button
                                 class="header-menu-item menu-check-item"
+                                id="btn-tap-editor"
+                            >
+                                <span class="menu-check">&#10003;</span>
+                                <span>TAP Editor</span>
+                            </button>
+                            <button
+                                class="header-menu-item menu-check-item"
                                 id="btn-disk-drive"
                             >
                                 <span class="menu-check">&#10003;</span>

--- a/src/js/css/tap-editor.css
+++ b/src/js/css/tap-editor.css
@@ -1,0 +1,783 @@
+/* ============================================
+   TAP EDITOR WINDOW
+   ============================================ */
+
+.tap-editor {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  font-family: var(--font-sans);
+}
+
+/* ---- Toolbar ---- */
+.tap-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--glass-border-subtle);
+}
+
+.tap-toolbar-group {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
+.tap-toolbar-group + .tap-toolbar-group {
+  margin-left: 4px;
+  padding-left: 8px;
+  border-left: 1px solid var(--glass-border-subtle);
+}
+
+.tap-toolbar-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 3px 8px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--control-bg);
+  border: 1px solid var(--control-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.12s;
+}
+
+.tap-toolbar-btn:hover {
+  color: var(--text-primary);
+  background: var(--glass-border);
+  border-color: var(--accent-blue-border);
+}
+
+.tap-toolbar-btn:active {
+  transform: scale(0.97);
+}
+
+.tap-toolbar-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
+.tap-toolbar-btn svg {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+}
+
+.tap-toolbar-btn.save.dirty {
+  border-color: var(--accent-orange-border);
+  color: var(--accent-orange);
+}
+
+/* ---- Filename Banner ---- */
+.tap-filename-banner {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  background: linear-gradient(135deg, var(--accent-blue-bg-strong) 0%, var(--accent-purple-bg-strong) 100%);
+  border-bottom: 1px solid var(--accent-blue-border-light);
+}
+
+.tap-filename-banner.hidden {
+  display: none;
+}
+
+.tap-filename-text {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+
+.tap-dirty-indicator {
+  font-size: 9px;
+  color: var(--accent-orange);
+  font-weight: 700;
+}
+
+/* ---- Block List ---- */
+.tap-block-list-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tap-block-list {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--input-bg-dark);
+  border: 1px solid var(--glass-border-subtle);
+  border-radius: var(--radius-sm);
+  margin: 0 8px;
+  padding: 2px 0;
+  min-height: 80px;
+}
+
+.tap-block-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+  border-left: 3px solid transparent;
+  transition: background 0.08s;
+  user-select: none;
+}
+
+.tap-block-row:hover {
+  background: var(--overlay-subtle);
+}
+
+.tap-block-row.selected {
+  background: var(--accent-blue-bg);
+  border-left-color: var(--accent-blue);
+}
+
+.tap-block-row.pair-start {
+  border-left-color: var(--accent-blue-border);
+  border-left-style: solid;
+}
+
+.tap-block-row.pair-end {
+  border-left-color: var(--accent-blue-border);
+  border-left-style: solid;
+}
+
+.tap-block-row.pair-start.selected,
+.tap-block-row.pair-end.selected {
+  border-left-color: var(--accent-blue);
+}
+
+.tap-block-index {
+  color: var(--text-muted);
+  min-width: 18px;
+  text-align: right;
+  font-size: 9px;
+}
+
+.tap-block-badge {
+  font-size: 8px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+  min-width: 36px;
+  text-align: center;
+}
+
+.tap-block-badge.header {
+  background: var(--accent-green-bg-strong);
+  border: 1px solid var(--accent-green-border-light);
+  color: var(--accent-green);
+}
+
+.tap-block-badge.data {
+  background: var(--accent-orange-bg-strong);
+  border: 1px solid var(--accent-orange-border-light);
+  color: var(--accent-orange);
+}
+
+.tap-block-name {
+  color: var(--text-primary);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tap-block-size {
+  color: var(--text-muted);
+  font-size: 9px;
+  flex-shrink: 0;
+}
+
+.tap-block-checksum {
+  flex-shrink: 0;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.tap-block-checksum.valid {
+  color: var(--accent-green);
+}
+
+.tap-block-checksum.invalid {
+  color: var(--accent-red);
+}
+
+.tap-block-actions {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.tap-block-row:hover .tap-block-actions {
+  opacity: 1;
+}
+
+.tap-block-row.selected .tap-block-actions {
+  opacity: 1;
+}
+
+.tap-block-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.1s;
+}
+
+.tap-block-action-btn:hover {
+  background: var(--control-bg);
+  color: var(--text-primary);
+}
+
+.tap-block-action-btn.delete:hover {
+  color: var(--accent-red);
+}
+
+.tap-block-action-btn svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* Drag-and-drop */
+.tap-block-drag-handle {
+  cursor: grab;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+
+.tap-block-row:hover .tap-block-drag-handle {
+  opacity: 0.6;
+}
+
+.tap-block-drag-handle:hover {
+  opacity: 1 !important;
+  color: var(--text-secondary);
+}
+
+.tap-block-drag-handle svg {
+  width: 10px;
+  height: 14px;
+  display: block;
+}
+
+.tap-block-row.dragging {
+  opacity: 0.3;
+}
+
+.tap-drop-indicator {
+  height: 2px;
+  background: var(--accent-blue);
+  margin: 0 8px;
+  border-radius: 1px;
+  pointer-events: none;
+}
+
+/* ---- Add Block Bar ---- */
+.tap-add-bar {
+  display: flex;
+  gap: 4px;
+  padding: 6px 8px;
+}
+
+.tap-add-btn {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: 1px dashed var(--control-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.tap-add-btn:hover {
+  color: var(--text-primary);
+  border-color: var(--accent-blue-border);
+  background: var(--accent-blue-bg);
+}
+
+.tap-add-btn svg {
+  width: 10px;
+  height: 10px;
+}
+
+/* ---- Add Block Form (inline) ---- */
+.tap-add-form {
+  padding: 8px;
+  margin: 0 8px 6px;
+  background: var(--glass-bg);
+  border: 1px solid var(--accent-blue-border);
+  border-radius: var(--radius-sm);
+}
+
+.tap-add-form.hidden {
+  display: none;
+}
+
+.tap-add-form-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.tap-add-form-row:last-child {
+  margin-bottom: 0;
+}
+
+.tap-add-form-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  min-width: 60px;
+  font-family: var(--font-sans);
+}
+
+.tap-add-form-input {
+  flex: 1;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 6px;
+  background: var(--input-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  outline: none;
+}
+
+.tap-add-form-input:focus {
+  border-color: var(--accent-blue-border);
+}
+
+.tap-add-form-select {
+  flex: 1;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  padding: 3px 6px;
+  background: var(--input-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  outline: none;
+}
+
+.tap-add-form-actions {
+  display: flex;
+  gap: 4px;
+  justify-content: flex-end;
+}
+
+.tap-add-form-btn {
+  padding: 3px 10px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid var(--control-border);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  transition: all 0.1s;
+}
+
+.tap-add-form-btn:hover {
+  color: var(--text-primary);
+}
+
+.tap-add-form-btn.primary {
+  background: var(--accent-blue-bg-strong);
+  border-color: var(--accent-blue-border);
+  color: var(--accent-blue);
+}
+
+.tap-add-form-btn.primary:hover {
+  background: var(--accent-blue-bg-stronger);
+}
+
+/* ---- Detail Panel ---- */
+.tap-detail-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-muted);
+  user-select: none;
+  transition: color 0.15s;
+}
+
+.tap-detail-toggle:hover {
+  color: var(--text-secondary);
+}
+
+.tap-detail-chevron {
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.tap-detail-toggle.open .tap-detail-chevron {
+  transform: rotate(90deg);
+}
+
+.tap-detail-panel {
+  border-top: 1px solid var(--glass-border-subtle);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.tap-detail-panel.hidden {
+  display: none;
+}
+
+.tap-detail-resize-handle {
+  height: 4px;
+  cursor: ns-resize;
+  background: transparent;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.tap-detail-resize-handle::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--glass-border-subtle);
+}
+
+.tap-detail-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--glass-border-subtle);
+}
+
+.tap-detail-tab {
+  padding: 4px 12px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.tap-detail-tab:hover {
+  color: var(--text-secondary);
+}
+
+.tap-detail-tab.active {
+  color: var(--accent-blue);
+  border-bottom-color: var(--accent-blue);
+}
+
+.tap-detail-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  min-height: 80px;
+}
+
+/* ---- Header Edit Form ---- */
+.tap-header-form {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 8px;
+  align-items: center;
+}
+
+.tap-header-label {
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  text-align: right;
+}
+
+.tap-header-input {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 6px;
+  background: var(--input-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.tap-header-input:focus {
+  border-color: var(--accent-blue-border);
+}
+
+.tap-header-select {
+  font-family: var(--font-sans);
+  font-size: 10px;
+  padding: 3px 6px;
+  background: var(--input-bg);
+  border: 1px solid var(--control-border);
+  border-radius: 3px;
+  color: var(--text-primary);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.tap-header-readonly {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 3px 6px;
+  color: var(--text-muted);
+}
+
+.tap-header-checksum-row {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 4px;
+  margin-top: 4px;
+  border-top: 1px solid var(--glass-border-subtle);
+}
+
+.tap-header-checksum-status {
+  font-size: 10px;
+  font-family: var(--font-mono);
+}
+
+.tap-header-checksum-status.valid {
+  color: var(--accent-green);
+}
+
+.tap-header-checksum-status.invalid {
+  color: var(--accent-red);
+}
+
+/* ---- Hex Viewer/Editor ---- */
+.tap-hex-container {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.6;
+  overflow-y: auto;
+  position: relative;
+}
+
+.tap-hex-row {
+  display: flex;
+  gap: 0;
+  white-space: nowrap;
+  padding: 0 4px;
+}
+
+.tap-hex-row:hover {
+  background: var(--overlay-subtle);
+}
+
+.tap-hex-offset {
+  color: var(--text-muted);
+  min-width: 48px;
+  text-align: right;
+  padding-right: 8px;
+  user-select: none;
+}
+
+.tap-hex-bytes {
+  display: flex;
+  gap: 0;
+  flex-shrink: 0;
+}
+
+.tap-hex-byte {
+  width: 22px;
+  text-align: center;
+  color: var(--text-primary);
+  cursor: text;
+  border-radius: 2px;
+  transition: background 0.08s;
+}
+
+.tap-hex-byte:hover {
+  background: var(--accent-blue-bg);
+}
+
+.tap-hex-byte.modified {
+  color: var(--accent-green);
+  background: var(--accent-green-bg);
+}
+
+.tap-hex-byte.editing {
+  background: var(--accent-blue-bg-strong);
+  outline: 1px solid var(--accent-blue-border);
+  color: var(--text-primary);
+}
+
+.tap-hex-spacer {
+  width: 8px;
+}
+
+.tap-hex-ascii {
+  color: var(--text-secondary);
+  padding-left: 8px;
+  border-left: 1px solid var(--glass-border-subtle);
+  letter-spacing: 0.5px;
+  user-select: none;
+}
+
+.tap-hex-ascii-char {
+  display: inline;
+}
+
+.tap-hex-ascii-char.non-printable {
+  color: var(--text-muted);
+}
+
+/* Virtualized hex scrolling spacer */
+.tap-hex-spacer-top,
+.tap-hex-spacer-bottom {
+  flex-shrink: 0;
+}
+
+/* ---- Empty State ---- */
+.tap-empty-state {
+  padding: 30px 20px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 11px;
+  font-style: italic;
+  opacity: 0.7;
+}
+
+.tap-empty-state-hint {
+  margin-top: 8px;
+  font-size: 10px;
+  font-style: normal;
+  color: var(--text-muted);
+  opacity: 0.6;
+}
+
+/* ---- Delete Confirmation ---- */
+.tap-delete-confirm {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  margin: 2px 8px;
+  background: var(--accent-red-bg);
+  border: 1px solid var(--accent-red-border);
+  border-radius: var(--radius-sm);
+  font-size: 10px;
+  color: var(--text-primary);
+}
+
+.tap-delete-confirm.hidden {
+  display: none;
+}
+
+.tap-delete-confirm-text {
+  flex: 1;
+  font-family: var(--font-sans);
+}
+
+.tap-delete-confirm-btn {
+  padding: 2px 8px;
+  font-family: var(--font-sans);
+  font-size: 9px;
+  font-weight: 500;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid var(--control-border);
+  background: var(--control-bg);
+  color: var(--text-secondary);
+  transition: all 0.1s;
+}
+
+.tap-delete-confirm-btn:hover {
+  color: var(--text-primary);
+}
+
+.tap-delete-confirm-btn.danger {
+  border-color: var(--accent-red-border);
+  color: var(--accent-red);
+}
+
+/* ---- Toast Notifications ---- */
+.tap-toast {
+  position: absolute;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 12px;
+  background: var(--glass-bg-header);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  color: var(--text-primary);
+  opacity: 0;
+  transition: opacity 0.2s;
+  pointer-events: none;
+  z-index: 10;
+  white-space: nowrap;
+}
+
+.tap-toast.visible {
+  opacity: 1;
+}
+
+/* ---- No-selection state for detail ---- */
+.tap-detail-empty {
+  padding: 16px;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-style: italic;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -17,6 +17,7 @@ import { SnapshotLoader } from "./snapshot/snapshot-loader.js";
 import { CPUDebuggerWindow } from "./debug/cpu-debugger-window.js";
 import { StackViewerWindow } from "./debug/stack-viewer-window.js";
 import { TapeWindow } from "./tape/tape-window.js";
+import { TAPEditorWindow } from "./tape/tap-editor-window.js";
 import { DiskWindow } from "./disk/disk-window.js";
 import { DiskExplorerWindow, DiskAnalysisWindow } from "./disk/disk-explorer-window.js";
 import { SoundWindow } from "./audio/sound-window.js";
@@ -66,6 +67,7 @@ class ZXSpectrumEmulator {
     this.displaySettingsWindow = null;
     this.cpuDebuggerWindow = null;
     this.tapeWindow = null;
+    this.tapEditorWindow = null;
     this.soundWindow = null;
     this.basicProgramWindow = null;
     this.ruleBuilderWindow = null;
@@ -158,6 +160,11 @@ class ZXSpectrumEmulator {
       this.tapeWindow = new TapeWindow(this.proxy);
       this.tapeWindow.create();
       this.windowManager.register(this.tapeWindow);
+
+      // Create TAP editor window
+      this.tapEditorWindow = new TAPEditorWindow(this.proxy);
+      this.tapEditorWindow.create();
+      this.windowManager.register(this.tapEditorWindow);
 
       // Create disk drive window (+3 only, but always available)
       this.diskWindow = new DiskWindow(this.proxy);
@@ -321,6 +328,7 @@ class ZXSpectrumEmulator {
         { id: "spectranet", visible: false },
         { id: "tnfs-browser", visible: false },
         { id: "save-states", visible: false },
+        { id: "tap-editor", visible: false },
         { id: "disk-window", visible: false },
         { id: "disk-explorer", visible: false },
         { id: "disk-analysis", visible: false },
@@ -481,6 +489,9 @@ class ZXSpectrumEmulator {
 
     // Wire TNFS browser window to snapshot loader (window was created in init())
     this.tnfsBrowserWindow.snapshotLoader = this.snapshotLoader;
+
+    // Wire TAP editor cross-reference to tape window
+    this.tapEditorWindow.tapeWindow = this.tapeWindow;
 
     // TAP loaded callback - show tape window with block list
     this.proxy.onTapLoaded = (blocks, metadata) => {
@@ -655,6 +666,16 @@ class ZXSpectrumEmulator {
     if (tapePlayerBtn) {
       tapePlayerBtn.addEventListener("click", () => {
         this.windowManager.toggleWindow("tape-window");
+        this.closeAllMenus();
+        this.refocusCanvas();
+      });
+    }
+
+    // View menu > TAP Editor
+    const tapEditorBtn = document.getElementById("btn-tap-editor");
+    if (tapEditorBtn) {
+      tapEditorBtn.addEventListener("click", () => {
+        this.windowManager.toggleWindow("tap-editor");
         this.closeAllMenus();
         this.refocusCanvas();
       });
@@ -904,6 +925,7 @@ class ZXSpectrumEmulator {
     const windowMap = {
       "btn-display": "display-settings",
       "btn-tape-player": "tape-window",
+      "btn-tap-editor": "tap-editor",
       "btn-disk-drive": "disk-window",
       "btn-disk-explorer": "disk-explorer",
       "btn-sound-debug": "sound-debug",
@@ -2056,6 +2078,11 @@ class ZXSpectrumEmulator {
     if (this.tapeWindow) {
       this.tapeWindow.destroy();
       this.tapeWindow = null;
+    }
+
+    if (this.tapEditorWindow) {
+      this.tapEditorWindow.destroy();
+      this.tapEditorWindow = null;
     }
 
     if (this.soundWindow) {

--- a/src/js/tape/tap-editor-window.js
+++ b/src/js/tape/tap-editor-window.js
@@ -1,0 +1,1228 @@
+/*
+ * tap-editor-window.js - TAP file editor window
+ *
+ * Provides a full-featured editor for TAP tape image files: block list with
+ * reordering, header field editing, hex viewer/editor, import/export, checksum
+ * validation, and integration with the emulator's tape system.
+ */
+
+import { BaseWindow } from "../windows/base-window.js";
+import {
+  parseTAP,
+  assembleTAP,
+  computeChecksum,
+  recalcChecksum,
+  updateHeaderPayload,
+  createHeaderBlock,
+  createDataBlock,
+  isHeader,
+  describeBlock,
+  FLAG_HEADER,
+  FLAG_DATA,
+  HEADER_PROGRAM,
+  HEADER_CODE,
+  HEADER_TYPE_NAMES,
+} from "./tap-parser.js";
+import "../css/tap-editor.css";
+
+/* SVG icon fragments */
+const ICON_PLUS = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><line x1="6" y1="2" x2="6" y2="10"/><line x1="2" y1="6" x2="10" y2="6"/></svg>`;
+const ICON_TRASH = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M2 3h8M4 3V2h4v1M3 3v7h6V3"/></svg>`;
+const ICON_UP = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6 2v8M3 5l3-3 3 3"/></svg>`;
+const ICON_DOWN = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6 10V2M3 7l3 3 3-3"/></svg>`;
+const ICON_DOWNLOAD = `<svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M6 2v6M3 6l3 3 3-3M2 10h8"/></svg>`;
+const ICON_GRIP = `<svg viewBox="0 0 8 14" fill="currentColor"><circle cx="2.5" cy="2" r="1"/><circle cx="5.5" cy="2" r="1"/><circle cx="2.5" cy="5" r="1"/><circle cx="5.5" cy="5" r="1"/><circle cx="2.5" cy="8" r="1"/><circle cx="5.5" cy="8" r="1"/><circle cx="2.5" cy="11" r="1"/><circle cx="5.5" cy="11" r="1"/></svg>`;
+const ICON_CHECK = `\u2713`;
+const ICON_CROSS = `\u2717`;
+const ICON_CHEVRON = `<svg class="tap-detail-chevron" viewBox="0 0 12 12" width="10" height="10"><path d="M4 2l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5"/></svg>`;
+
+const HEX_BYTES_PER_ROW = 16;
+const HEX_VISIBLE_ROWS = 32;
+const HEX_ROW_HEIGHT = 17; // approx line-height in pixels
+
+export class TAPEditorWindow extends BaseWindow {
+  constructor(proxy) {
+    super({
+      id: "tap-editor",
+      title: "TAP Editor",
+      minWidth: 480,
+      minHeight: 400,
+      defaultWidth: 600,
+      defaultHeight: 550,
+      defaultPosition: { x: 150, y: 80 },
+    });
+
+    this._proxy = proxy;
+    this._blocks = [];
+    this._selectedBlockIndex = -1;
+    this._currentFilename = null;
+    this._dirty = false;
+    this._detailPanelOpen = true;
+    this._detailPanelHeight = null;
+    this._detailTab = "header"; // "header" or "hex"
+    this._addFormVisible = false;
+    this._deleteConfirmIndex = -1;
+    this._hexModifiedBytes = new Set(); // track modified byte offsets for highlighting
+    this._hexEditingByte = -1; // currently editing byte index
+    this._hexEditBuffer = ""; // partial hex input
+    this._hexScrollTop = 0;
+    this._fileInput = null;
+    this._mergeFileInput = null;
+    this._importFileInput = null;
+    this._toastTimeout = null;
+
+    // Drag state
+    this._dragIndex = -1;
+    this._dragOverIndex = -1;
+
+    // Cross-reference set by main.js
+    this.tapeWindow = null;
+  }
+
+  getState() {
+    const state = super.getState();
+    state.currentFilename = this._currentFilename;
+    state.detailPanelOpen = this._detailPanelOpen;
+    state.detailPanelHeight = this._detailPanelHeight;
+    state.detailTab = this._detailTab;
+    state.selectedBlockIndex = this._selectedBlockIndex;
+    return state;
+  }
+
+  restoreState(state) {
+    if (state.currentFilename != null) this._currentFilename = state.currentFilename;
+    if (state.detailPanelOpen != null) this._detailPanelOpen = state.detailPanelOpen;
+    if (state.detailPanelHeight != null) this._detailPanelHeight = state.detailPanelHeight;
+    if (state.detailTab) this._detailTab = state.detailTab;
+    if (state.selectedBlockIndex != null) this._selectedBlockIndex = state.selectedBlockIndex;
+    super.restoreState(state);
+    // Restore panel state after DOM is ready
+    this._applyDetailPanelState();
+  }
+
+  renderContent() {
+    return `
+      <div class="tap-editor">
+        <div class="tap-toolbar">
+          <div class="tap-toolbar-group">
+            <button class="tap-toolbar-btn" data-action="new" title="New empty TAP">
+              ${ICON_PLUS} New
+            </button>
+            <button class="tap-toolbar-btn" data-action="open" title="Open TAP file">
+              Open
+            </button>
+            <button class="tap-toolbar-btn save" data-action="save" title="Save TAP file">
+              Save
+            </button>
+            <button class="tap-toolbar-btn" data-action="merge" title="Merge blocks from another TAP">
+              Merge
+            </button>
+          </div>
+          <div class="tap-toolbar-group">
+            <button class="tap-toolbar-btn" data-action="import-tape" title="Import currently loaded tape">
+              Import Tape
+            </button>
+            <button class="tap-toolbar-btn" data-action="load-emu" title="Load edited TAP into emulator">
+              Load into Emu
+            </button>
+          </div>
+          <div class="tap-toolbar-group">
+            <button class="tap-toolbar-btn" data-action="fix-checksums" title="Fix all checksums">
+              Fix Checksums
+            </button>
+          </div>
+        </div>
+        <div class="tap-filename-banner hidden" id="tap-editor-filename"></div>
+        <div class="tap-block-list-container">
+          <div class="tap-block-list" id="tap-editor-blocks">
+            <div class="tap-empty-state">
+              No TAP file loaded
+              <div class="tap-empty-state-hint">Open a file or import the current tape</div>
+            </div>
+          </div>
+          <div class="tap-delete-confirm hidden" id="tap-editor-delete-confirm">
+            <span class="tap-delete-confirm-text">Delete paired data block too?</span>
+            <button class="tap-delete-confirm-btn danger" data-confirm="pair">Delete Pair</button>
+            <button class="tap-delete-confirm-btn" data-confirm="single">Header Only</button>
+            <button class="tap-delete-confirm-btn" data-confirm="cancel">Cancel</button>
+          </div>
+          <div class="tap-add-form hidden" id="tap-editor-add-form">
+            <div class="tap-add-form-row">
+              <span class="tap-add-form-label">Type</span>
+              <select class="tap-add-form-select" id="tap-add-type">
+                <option value="0">Program</option>
+                <option value="3" selected>Code</option>
+                <option value="1">Num Array</option>
+                <option value="2">Char Array</option>
+              </select>
+            </div>
+            <div class="tap-add-form-row">
+              <span class="tap-add-form-label">Filename</span>
+              <input class="tap-add-form-input" id="tap-add-filename" type="text" maxlength="10" value="untitled  " />
+            </div>
+            <div class="tap-add-form-row" id="tap-add-param1-row">
+              <span class="tap-add-form-label" id="tap-add-param1-label">Start Addr</span>
+              <input class="tap-add-form-input" id="tap-add-param1" type="number" min="0" max="65535" value="32768" />
+            </div>
+            <div class="tap-add-form-row" id="tap-add-param2-row">
+              <span class="tap-add-form-label" id="tap-add-param2-label">Param 2</span>
+              <input class="tap-add-form-input" id="tap-add-param2" type="number" min="0" max="65535" value="32768" />
+            </div>
+            <div class="tap-add-form-actions">
+              <button class="tap-add-form-btn" data-form-action="cancel">Cancel</button>
+              <button class="tap-add-form-btn primary" data-form-action="create">Create</button>
+            </div>
+          </div>
+          <div class="tap-add-bar">
+            <button class="tap-add-btn" data-action="add-pair" title="Add a header+data block pair">
+              ${ICON_PLUS} Add Block Pair
+            </button>
+            <button class="tap-add-btn" data-action="import-binary" title="Import a binary file as Code block">
+              ${ICON_PLUS} Import Binary
+            </button>
+          </div>
+        </div>
+        <div class="tap-detail-toggle" id="tap-editor-detail-toggle">
+          ${ICON_CHEVRON}
+          <span>Details</span>
+        </div>
+        <div class="tap-detail-panel${this._detailPanelOpen ? "" : " hidden"}" id="tap-editor-detail-panel">
+          <div class="tap-detail-resize-handle" id="tap-editor-detail-resize"></div>
+          <div class="tap-detail-tabs">
+            <button class="tap-detail-tab${this._detailTab === "header" ? " active" : ""}" data-tab="header">Header</button>
+            <button class="tap-detail-tab${this._detailTab === "hex" ? " active" : ""}" data-tab="hex">Hex</button>
+          </div>
+          <div class="tap-detail-content" id="tap-editor-detail-content">
+            <div class="tap-detail-empty">Select a block to view details</div>
+          </div>
+        </div>
+        <div class="tap-toast" id="tap-editor-toast"></div>
+      </div>
+    `;
+  }
+
+  onContentRendered() {
+    this._cacheElements();
+    this._setupToolbar();
+    this._setupBlockList();
+    this._setupAddForm();
+    this._setupDeleteConfirm();
+    this._setupDetailPanel();
+    this._setupFileInputs();
+    this._applyDetailPanelState();
+  }
+
+  // ─── Element caching ──────────────────────────────────────────
+
+  _cacheElements() {
+    const ce = this.contentElement;
+    this._els = {
+      blockList: ce.querySelector("#tap-editor-blocks"),
+      filenameBanner: ce.querySelector("#tap-editor-filename"),
+      addForm: ce.querySelector("#tap-editor-add-form"),
+      deleteConfirm: ce.querySelector("#tap-editor-delete-confirm"),
+      detailToggle: ce.querySelector("#tap-editor-detail-toggle"),
+      detailPanel: ce.querySelector("#tap-editor-detail-panel"),
+      detailContent: ce.querySelector("#tap-editor-detail-content"),
+      detailResize: ce.querySelector("#tap-editor-detail-resize"),
+      toast: ce.querySelector("#tap-editor-toast"),
+      addType: ce.querySelector("#tap-add-type"),
+      addFilename: ce.querySelector("#tap-add-filename"),
+      addParam1: ce.querySelector("#tap-add-param1"),
+      addParam2: ce.querySelector("#tap-add-param2"),
+      addParam1Row: ce.querySelector("#tap-add-param1-row"),
+      addParam2Row: ce.querySelector("#tap-add-param2-row"),
+      addParam1Label: ce.querySelector("#tap-add-param1-label"),
+      addParam2Label: ce.querySelector("#tap-add-param2-label"),
+      saveBtn: ce.querySelector('[data-action="save"]'),
+    };
+  }
+
+  // ─── Toolbar ──────────────────────────────────────────────────
+
+  _setupToolbar() {
+    const toolbar = this.contentElement.querySelector(".tap-toolbar");
+    toolbar.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      const action = btn.dataset.action;
+      switch (action) {
+        case "new": this._newTape(); break;
+        case "open": this._openFile(); break;
+        case "save": this._saveFile(); break;
+        case "merge": this._mergeFile(); break;
+        case "import-tape": this._importCurrentTape(); break;
+        case "load-emu": this._loadIntoEmulator(); break;
+        case "fix-checksums": this._fixAllChecksums(); break;
+      }
+    });
+  }
+
+  // ─── File inputs (hidden) ─────────────────────────────────────
+
+  _setupFileInputs() {
+    // Main open file input
+    this._fileInput = document.createElement("input");
+    this._fileInput.type = "file";
+    this._fileInput.accept = ".tap";
+    this._fileInput.style.display = "none";
+    this.contentElement.appendChild(this._fileInput);
+    this._fileInput.addEventListener("change", (e) => {
+      const file = e.target.files[0];
+      if (file) this._loadFile(file);
+      this._fileInput.value = "";
+    });
+
+    // Merge file input
+    this._mergeFileInput = document.createElement("input");
+    this._mergeFileInput.type = "file";
+    this._mergeFileInput.accept = ".tap";
+    this._mergeFileInput.style.display = "none";
+    this.contentElement.appendChild(this._mergeFileInput);
+    this._mergeFileInput.addEventListener("change", (e) => {
+      const file = e.target.files[0];
+      if (file) this._doMergeFile(file);
+      this._mergeFileInput.value = "";
+    });
+
+    // Import binary file input
+    this._importFileInput = document.createElement("input");
+    this._importFileInput.type = "file";
+    this._importFileInput.style.display = "none";
+    this.contentElement.appendChild(this._importFileInput);
+    this._importFileInput.addEventListener("change", (e) => {
+      const file = e.target.files[0];
+      if (file) this._doImportBinary(file);
+      this._importFileInput.value = "";
+    });
+  }
+
+  // ─── Block list ───────────────────────────────────────────────
+
+  _setupBlockList() {
+    const list = this._els.blockList;
+
+    // Click to select
+    list.addEventListener("click", (e) => {
+      const row = e.target.closest(".tap-block-row");
+      if (!row) return;
+
+      // Check action buttons
+      const actionBtn = e.target.closest(".tap-block-action-btn");
+      if (actionBtn) {
+        const idx = parseInt(row.dataset.index, 10);
+        const action = actionBtn.dataset.action;
+        if (action === "delete") this._startDelete(idx);
+        else if (action === "up") this._moveBlock(idx, -1);
+        else if (action === "down") this._moveBlock(idx, 1);
+        else if (action === "export") this._exportBlock(idx);
+        return;
+      }
+
+      // Don't select if clicking drag handle
+      if (e.target.closest(".tap-block-drag-handle")) return;
+
+      const idx = parseInt(row.dataset.index, 10);
+      this._selectBlock(idx);
+    });
+
+    // Add block buttons
+    const addBar = this.contentElement.querySelector(".tap-add-bar");
+    addBar.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-action]");
+      if (!btn) return;
+      if (btn.dataset.action === "add-pair") this._showAddForm();
+      else if (btn.dataset.action === "import-binary") this._importFileInput.click();
+    });
+
+    // Drag-and-drop
+    list.addEventListener("mousedown", (e) => {
+      const handle = e.target.closest(".tap-block-drag-handle");
+      if (!handle) return;
+      const row = handle.closest(".tap-block-row");
+      if (!row) return;
+      e.preventDefault();
+      this._startDrag(parseInt(row.dataset.index, 10), e);
+    });
+  }
+
+  _renderBlocks() {
+    const list = this._els.blockList;
+    if (!this._blocks.length) {
+      list.innerHTML = `<div class="tap-empty-state">No TAP file loaded<div class="tap-empty-state-hint">Open a file or import the current tape</div></div>`;
+      return;
+    }
+
+    // Identify header+data pairs
+    const pairs = this._identifyPairs();
+
+    let html = "";
+    for (let i = 0; i < this._blocks.length; i++) {
+      const block = this._blocks[i];
+      const desc = describeBlock(block);
+      const selected = i === this._selectedBlockIndex;
+      const pairClass = pairs[i] === "start" ? " pair-start" : pairs[i] === "end" ? " pair-end" : "";
+      const dragging = i === this._dragIndex ? " dragging" : "";
+      const csClass = block.checksumValid ? "valid" : "invalid";
+      const csIcon = block.checksumValid ? ICON_CHECK : ICON_CROSS;
+      const badgeClass = isHeader(block) ? "header" : "data";
+
+      html += `<div class="tap-block-row${selected ? " selected" : ""}${pairClass}${dragging}" data-index="${i}">
+        <span class="tap-block-drag-handle" title="Drag to reorder">${ICON_GRIP}</span>
+        <span class="tap-block-index">${i}</span>
+        <span class="tap-block-badge ${badgeClass}">${desc.badge}</span>
+        <span class="tap-block-name">${this._escapeHtml(desc.name)}</span>
+        <span class="tap-block-size">${desc.size}</span>
+        <span class="tap-block-checksum ${csClass}" title="Checksum: ${block.checksum.toString(16).padStart(2, "0")}h">${csIcon}</span>
+        <span class="tap-block-actions">
+          <button class="tap-block-action-btn" data-action="up" title="Move up">${ICON_UP}</button>
+          <button class="tap-block-action-btn" data-action="down" title="Move down">${ICON_DOWN}</button>
+          <button class="tap-block-action-btn" data-action="export" title="Export block">${ICON_DOWNLOAD}</button>
+          <button class="tap-block-action-btn delete" data-action="delete" title="Delete block">${ICON_TRASH}</button>
+        </span>
+      </div>`;
+    }
+    list.innerHTML = html;
+  }
+
+  _identifyPairs() {
+    const pairs = {};
+    for (let i = 0; i < this._blocks.length - 1; i++) {
+      if (isHeader(this._blocks[i]) && this._blocks[i + 1].flag === FLAG_DATA) {
+        pairs[i] = "start";
+        pairs[i + 1] = "end";
+      }
+    }
+    return pairs;
+  }
+
+  _selectBlock(index) {
+    if (index < 0 || index >= this._blocks.length) {
+      this._selectedBlockIndex = -1;
+    } else {
+      this._selectedBlockIndex = index;
+    }
+    // Update row highlight
+    const rows = this._els.blockList.querySelectorAll(".tap-block-row");
+    rows.forEach((row) => {
+      row.classList.toggle("selected", parseInt(row.dataset.index, 10) === this._selectedBlockIndex);
+    });
+    this._renderDetail();
+  }
+
+  // ─── Add block form ───────────────────────────────────────────
+
+  _setupAddForm() {
+    const form = this._els.addForm;
+
+    // Type change updates param labels
+    this._els.addType.addEventListener("change", () => this._updateAddFormLabels());
+
+    // Form buttons
+    form.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-form-action]");
+      if (!btn) return;
+      if (btn.dataset.formAction === "cancel") {
+        this._hideAddForm();
+      } else if (btn.dataset.formAction === "create") {
+        this._createBlockPair();
+      }
+    });
+  }
+
+  _showAddForm() {
+    this._addFormVisible = true;
+    this._els.addForm.classList.remove("hidden");
+    this._updateAddFormLabels();
+    this._els.addFilename.value = "untitled  ";
+    this._els.addFilename.focus();
+    this._els.addFilename.select();
+  }
+
+  _hideAddForm() {
+    this._addFormVisible = false;
+    this._els.addForm.classList.add("hidden");
+  }
+
+  _updateAddFormLabels() {
+    const type = parseInt(this._els.addType.value, 10);
+    if (type === HEADER_PROGRAM) {
+      this._els.addParam1Label.textContent = "Autostart";
+      this._els.addParam1.value = "32768";
+      this._els.addParam2Label.textContent = "Var Offset";
+      this._els.addParam2.value = "32768";
+      this._els.addParam2Row.style.display = "";
+    } else if (type === HEADER_CODE) {
+      this._els.addParam1Label.textContent = "Start Addr";
+      this._els.addParam1.value = "32768";
+      this._els.addParam2Label.textContent = "";
+      this._els.addParam2Row.style.display = "none";
+    } else {
+      this._els.addParam1Label.textContent = "Param 1";
+      this._els.addParam1.value = "0";
+      this._els.addParam2Label.textContent = "Param 2";
+      this._els.addParam2.value = "0";
+      this._els.addParam2Row.style.display = "";
+    }
+  }
+
+  _createBlockPair() {
+    const type = parseInt(this._els.addType.value, 10);
+    const filename = this._els.addFilename.value || "untitled";
+    const param1 = parseInt(this._els.addParam1.value, 10) || 0;
+    const param2 = type === HEADER_CODE ? 32768 : (parseInt(this._els.addParam2.value, 10) || 0);
+    const emptyData = new Uint8Array(0);
+
+    const header = createHeaderBlock(type, filename, 0, param1, param2);
+    const data = createDataBlock(emptyData);
+
+    // Insert after selected or at end
+    const insertAt = this._selectedBlockIndex >= 0 ? this._selectedBlockIndex + 1 : this._blocks.length;
+    this._blocks.splice(insertAt, 0, header, data);
+    this._markDirty();
+    this._hideAddForm();
+    this._renderBlocks();
+    this._selectBlock(insertAt);
+  }
+
+  // ─── Delete confirmation ──────────────────────────────────────
+
+  _setupDeleteConfirm() {
+    const confirm = this._els.deleteConfirm;
+    confirm.addEventListener("click", (e) => {
+      const btn = e.target.closest("[data-confirm]");
+      if (!btn) return;
+      const action = btn.dataset.confirm;
+      if (action === "pair") this._doDelete(true);
+      else if (action === "single") this._doDelete(false);
+      else this._cancelDelete();
+    });
+  }
+
+  _startDelete(index) {
+    // If it's a header with a paired data block, show confirmation
+    const block = this._blocks[index];
+    const pairs = this._identifyPairs();
+    if (pairs[index] === "start") {
+      this._deleteConfirmIndex = index;
+      this._els.deleteConfirm.classList.remove("hidden");
+    } else if (pairs[index] === "end") {
+      // Deleting a data block — just delete it
+      this._deleteConfirmIndex = index;
+      this._doDelete(false);
+    } else {
+      // No pair — direct delete
+      this._deleteConfirmIndex = index;
+      this._doDelete(false);
+    }
+  }
+
+  _doDelete(includePair) {
+    const idx = this._deleteConfirmIndex;
+    if (idx < 0 || idx >= this._blocks.length) return;
+
+    if (includePair && idx + 1 < this._blocks.length) {
+      this._blocks.splice(idx, 2);
+    } else {
+      this._blocks.splice(idx, 1);
+    }
+
+    this._markDirty();
+    this._cancelDelete();
+
+    // Adjust selection
+    if (this._selectedBlockIndex >= this._blocks.length) {
+      this._selectedBlockIndex = this._blocks.length - 1;
+    }
+    this._renderBlocks();
+    this._renderDetail();
+  }
+
+  _cancelDelete() {
+    this._deleteConfirmIndex = -1;
+    this._els.deleteConfirm.classList.add("hidden");
+  }
+
+  // ─── Block reordering ────────────────────────────────────────
+
+  _moveBlock(index, direction) {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= this._blocks.length) return;
+
+    // Check if this is part of a pair; move the pair together
+    const pairs = this._identifyPairs();
+    if (pairs[index] === "start" && direction === 1) {
+      // Move header+data pair down: need to swap pair with the block after it
+      if (index + 2 >= this._blocks.length) return;
+      const [h, d] = this._blocks.splice(index, 2);
+      this._blocks.splice(index + 1, 0, h, d);
+      if (this._selectedBlockIndex === index) this._selectedBlockIndex = index + 1;
+      else if (this._selectedBlockIndex === index + 1) this._selectedBlockIndex = index + 2;
+    } else if (pairs[index] === "end" && direction === -1) {
+      // Move data block up means move the pair up
+      const pairStart = index - 1;
+      if (pairStart <= 0) return;
+      const [h, d] = this._blocks.splice(pairStart, 2);
+      this._blocks.splice(pairStart - 1, 0, h, d);
+      if (this._selectedBlockIndex === pairStart) this._selectedBlockIndex = pairStart - 1;
+      else if (this._selectedBlockIndex === index) this._selectedBlockIndex = index - 1;
+    } else if (pairs[index] === "start" && direction === -1) {
+      if (index <= 0) return;
+      const [h, d] = this._blocks.splice(index, 2);
+      this._blocks.splice(index - 1, 0, h, d);
+      if (this._selectedBlockIndex === index) this._selectedBlockIndex = index - 1;
+      else if (this._selectedBlockIndex === index + 1) this._selectedBlockIndex = index;
+    } else if (pairs[index] === "end" && direction === 1) {
+      const pairStart = index - 1;
+      if (index + 1 >= this._blocks.length) return;
+      const [h, d] = this._blocks.splice(pairStart, 2);
+      this._blocks.splice(pairStart + 1, 0, h, d);
+      if (this._selectedBlockIndex === pairStart) this._selectedBlockIndex = pairStart + 1;
+      else if (this._selectedBlockIndex === index) this._selectedBlockIndex = index + 1;
+    } else {
+      // Single block move
+      const [block] = this._blocks.splice(index, 1);
+      this._blocks.splice(newIndex, 0, block);
+      if (this._selectedBlockIndex === index) this._selectedBlockIndex = newIndex;
+    }
+
+    this._markDirty();
+    this._renderBlocks();
+  }
+
+  // Drag-and-drop reordering
+  _startDrag(index, e) {
+    this._dragIndex = index;
+    this._dragOverIndex = index;
+    const list = this._els.blockList;
+    const startY = e.clientY;
+
+    const rows = list.querySelectorAll(".tap-block-row");
+    const rowRects = Array.from(rows).map((r) => r.getBoundingClientRect());
+
+    const onMouseMove = (ev) => {
+      const y = ev.clientY;
+      let overIndex = this._dragIndex;
+      for (let i = 0; i < rowRects.length; i++) {
+        const mid = rowRects[i].top + rowRects[i].height / 2;
+        if (y < mid) {
+          overIndex = i;
+          break;
+        }
+        overIndex = i + 1;
+      }
+      if (overIndex !== this._dragOverIndex) {
+        this._dragOverIndex = overIndex;
+        // Visual feedback: highlight target position
+        rows.forEach((r) => r.classList.remove("dragging"));
+        const srcRow = list.querySelector(`[data-index="${this._dragIndex}"]`);
+        if (srcRow) srcRow.classList.add("dragging");
+      }
+    };
+
+    const onMouseUp = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+      const from = this._dragIndex;
+      let to = this._dragOverIndex;
+      this._dragIndex = -1;
+      this._dragOverIndex = -1;
+
+      if (from === to || from === to - 1) {
+        this._renderBlocks();
+        return;
+      }
+
+      // Perform the move
+      const [block] = this._blocks.splice(from, 1);
+      const insertAt = to > from ? to - 1 : to;
+      this._blocks.splice(insertAt, 0, block);
+
+      if (this._selectedBlockIndex === from) {
+        this._selectedBlockIndex = insertAt;
+      } else if (from < this._selectedBlockIndex && insertAt >= this._selectedBlockIndex) {
+        this._selectedBlockIndex--;
+      } else if (from > this._selectedBlockIndex && insertAt <= this._selectedBlockIndex) {
+        this._selectedBlockIndex++;
+      }
+
+      this._markDirty();
+      this._renderBlocks();
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+  }
+
+  // ─── Detail panel ─────────────────────────────────────────────
+
+  _setupDetailPanel() {
+    // Toggle
+    this._els.detailToggle.addEventListener("click", () => {
+      this._detailPanelOpen = !this._detailPanelOpen;
+      this._applyDetailPanelState();
+    });
+
+    // Tabs
+    const tabContainer = this.contentElement.querySelector(".tap-detail-tabs");
+    tabContainer.addEventListener("click", (e) => {
+      const tab = e.target.closest("[data-tab]");
+      if (!tab) return;
+      this._detailTab = tab.dataset.tab;
+      tabContainer.querySelectorAll(".tap-detail-tab").forEach((t) => {
+        t.classList.toggle("active", t.dataset.tab === this._detailTab);
+      });
+      this._renderDetail();
+    });
+
+    // Resize handle
+    this._setupDetailResize();
+  }
+
+  _applyDetailPanelState() {
+    if (!this._els) return;
+    const panel = this._els.detailPanel;
+    const toggle = this._els.detailToggle;
+    if (this._detailPanelOpen) {
+      panel.classList.remove("hidden");
+      toggle.classList.add("open");
+      if (this._detailPanelHeight) {
+        panel.style.height = `${this._detailPanelHeight}px`;
+      } else {
+        panel.style.height = "200px";
+      }
+    } else {
+      panel.classList.add("hidden");
+      toggle.classList.remove("open");
+    }
+  }
+
+  _setupDetailResize() {
+    let startY = 0;
+    let startH = 0;
+
+    const onMove = (e) => {
+      const dy = startY - e.clientY;
+      const newH = Math.max(100, startH + dy);
+      this._els.detailPanel.style.height = `${newH}px`;
+      this._detailPanelHeight = newH;
+    };
+
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+    };
+
+    this._els.detailResize.addEventListener("mousedown", (e) => {
+      e.preventDefault();
+      startY = e.clientY;
+      startH = this._els.detailPanel.offsetHeight;
+      document.addEventListener("mousemove", onMove);
+      document.addEventListener("mouseup", onUp);
+    });
+  }
+
+  _renderDetail() {
+    const content = this._els.detailContent;
+    if (this._selectedBlockIndex < 0 || this._selectedBlockIndex >= this._blocks.length) {
+      content.innerHTML = `<div class="tap-detail-empty">Select a block to view details</div>`;
+      return;
+    }
+
+    const block = this._blocks[this._selectedBlockIndex];
+    if (this._detailTab === "header" && isHeader(block)) {
+      this._renderHeaderEditor(block);
+    } else if (this._detailTab === "header" && !isHeader(block)) {
+      content.innerHTML = `<div class="tap-detail-empty">Data block — switch to Hex tab to view/edit raw bytes</div>`;
+    } else {
+      this._renderHexEditor(block);
+    }
+  }
+
+  // ─── Header editor ────────────────────────────────────────────
+
+  _renderHeaderEditor(block) {
+    const content = this._els.detailContent;
+    const typeOptions = HEADER_TYPE_NAMES.map((name, i) =>
+      `<option value="${i}"${i === block.headerType ? " selected" : ""}>${name}</option>`
+    ).join("");
+
+    const isProgram = block.headerType === HEADER_PROGRAM;
+    const isCode = block.headerType === HEADER_CODE;
+    const param1Label = isProgram ? "Autostart" : isCode ? "Start Addr" : "Param 1";
+    const param2Label = isProgram ? "Var Offset" : "Param 2";
+    const csClass = block.checksumValid ? "valid" : "invalid";
+    const csText = block.checksumValid
+      ? `${ICON_CHECK} Valid (${block.checksum.toString(16).padStart(2, "0")}h)`
+      : `${ICON_CROSS} Invalid (stored: ${block.checksum.toString(16).padStart(2, "0")}h, expected: ${computeChecksum(block.flag, block.payload).toString(16).padStart(2, "0")}h)`;
+
+    content.innerHTML = `
+      <div class="tap-header-form">
+        <span class="tap-header-label">Filename</span>
+        <input class="tap-header-input" id="tap-hdr-filename" type="text" maxlength="10" value="${this._escapeAttr(block.filename)}" />
+
+        <span class="tap-header-label">Type</span>
+        <select class="tap-header-select" id="tap-hdr-type">${typeOptions}</select>
+
+        <span class="tap-header-label">Data Length</span>
+        <span class="tap-header-readonly">${block.dataLength}</span>
+
+        <span class="tap-header-label">${param1Label}</span>
+        <input class="tap-header-input" id="tap-hdr-param1" type="number" min="0" max="65535" value="${block.param1}" />
+
+        <span class="tap-header-label">${param2Label}</span>
+        <input class="tap-header-input" id="tap-hdr-param2" type="number" min="0" max="65535" value="${block.param2}" />
+
+        <div class="tap-header-checksum-row">
+          <span class="tap-header-checksum-status ${csClass}">${csText}</span>
+          ${!block.checksumValid ? `<button class="tap-add-form-btn primary" id="tap-hdr-fix-checksum">Fix</button>` : ""}
+        </div>
+      </div>
+    `;
+
+    // Wire up editing
+    const filenameInput = content.querySelector("#tap-hdr-filename");
+    const typeSelect = content.querySelector("#tap-hdr-type");
+    const param1Input = content.querySelector("#tap-hdr-param1");
+    const param2Input = content.querySelector("#tap-hdr-param2");
+    const fixBtn = content.querySelector("#tap-hdr-fix-checksum");
+
+    const update = () => {
+      block.filename = (filenameInput.value || "").padEnd(10, " ").substring(0, 10);
+      block.headerType = parseInt(typeSelect.value, 10);
+      block.param1 = parseInt(param1Input.value, 10) || 0;
+      block.param2 = parseInt(param2Input.value, 10) || 0;
+      updateHeaderPayload(block);
+      this._markDirty();
+      this._renderBlocks();
+    };
+
+    filenameInput.addEventListener("change", update);
+    typeSelect.addEventListener("change", () => {
+      update();
+      this._renderHeaderEditor(block); // Re-render to update labels
+    });
+    param1Input.addEventListener("change", update);
+    param2Input.addEventListener("change", update);
+
+    if (fixBtn) {
+      fixBtn.addEventListener("click", () => {
+        recalcChecksum(block);
+        this._markDirty();
+        this._renderBlocks();
+        this._renderHeaderEditor(block);
+      });
+    }
+  }
+
+  // ─── Hex editor ───────────────────────────────────────────────
+
+  _renderHexEditor(block) {
+    const content = this._els.detailContent;
+    // Include flag byte and checksum in the hex view for full transparency
+    const fullData = new Uint8Array(1 + block.payload.length + 1);
+    fullData[0] = block.flag;
+    fullData.set(block.payload, 1);
+    fullData[fullData.length - 1] = block.checksum;
+
+    const totalRows = Math.ceil(fullData.length / HEX_BYTES_PER_ROW);
+
+    if (totalRows <= HEX_VISIBLE_ROWS * 2) {
+      // Small enough to render all rows
+      content.innerHTML = `<div class="tap-hex-container">${this._buildHexRows(fullData, 0, totalRows)}</div>`;
+    } else {
+      // Virtualized rendering
+      const totalHeight = totalRows * HEX_ROW_HEIGHT;
+      content.innerHTML = `<div class="tap-hex-container" style="height:100%;overflow-y:auto;">
+        <div style="height:${totalHeight}px;position:relative;" id="tap-hex-virtual">
+          <div id="tap-hex-rows" style="position:absolute;left:0;right:0;"></div>
+        </div>
+      </div>`;
+
+      const container = content.querySelector(".tap-hex-container");
+      const rowsDiv = content.querySelector("#tap-hex-rows");
+
+      const renderVisible = () => {
+        const scrollTop = container.scrollTop;
+        const startRow = Math.max(0, Math.floor(scrollTop / HEX_ROW_HEIGHT) - 2);
+        const endRow = Math.min(totalRows, startRow + HEX_VISIBLE_ROWS + 4);
+        rowsDiv.style.top = `${startRow * HEX_ROW_HEIGHT}px`;
+        rowsDiv.innerHTML = this._buildHexRows(fullData, startRow, endRow);
+      };
+
+      container.addEventListener("scroll", renderVisible);
+      renderVisible();
+    }
+
+    // Wire hex editing
+    content.addEventListener("click", (e) => {
+      const byteEl = e.target.closest(".tap-hex-byte");
+      if (!byteEl) return;
+      const offset = parseInt(byteEl.dataset.offset, 10);
+      this._startHexEdit(block, fullData, offset, byteEl);
+    });
+  }
+
+  _buildHexRows(data, startRow, endRow) {
+    let html = "";
+    for (let row = startRow; row < endRow; row++) {
+      const offset = row * HEX_BYTES_PER_ROW;
+      if (offset >= data.length) break;
+
+      const offsetStr = offset.toString(16).padStart(4, "0");
+
+      let hexCells = "";
+      let asciiChars = "";
+      for (let col = 0; col < HEX_BYTES_PER_ROW; col++) {
+        const byteOffset = offset + col;
+        if (col === 8) hexCells += `<span class="tap-hex-spacer"></span>`;
+        if (byteOffset < data.length) {
+          const val = data[byteOffset];
+          const hexStr = val.toString(16).padStart(2, "0");
+          const modified = this._hexModifiedBytes.has(byteOffset) ? " modified" : "";
+          hexCells += `<span class="tap-hex-byte${modified}" data-offset="${byteOffset}">${hexStr}</span>`;
+
+          const ch = val >= 0x20 && val <= 0x7e ? String.fromCharCode(val) : ".";
+          const npClass = val < 0x20 || val > 0x7e ? " non-printable" : "";
+          asciiChars += `<span class="tap-hex-ascii-char${npClass}">${this._escapeHtml(ch)}</span>`;
+        } else {
+          hexCells += `<span class="tap-hex-byte" style="visibility:hidden">  </span>`;
+          asciiChars += " ";
+        }
+      }
+
+      html += `<div class="tap-hex-row"><span class="tap-hex-offset">${offsetStr}</span><span class="tap-hex-bytes">${hexCells}</span><span class="tap-hex-ascii">${asciiChars}</span></div>`;
+    }
+    return html;
+  }
+
+  _startHexEdit(block, fullData, offset, element) {
+    // Don't allow editing flag byte (offset 0) — it defines the block type
+    if (offset === 0) {
+      this._showToast("Flag byte is read-only");
+      return;
+    }
+    // Don't edit checksum byte directly — use Fix Checksum
+    if (offset === fullData.length - 1) {
+      this._showToast("Use Fix Checksums to update the checksum");
+      return;
+    }
+
+    this._hexEditingByte = offset;
+    this._hexEditBuffer = "";
+    element.classList.add("editing");
+    element.textContent = "__";
+
+    const onKey = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const key = e.key.toLowerCase();
+
+      if (key === "escape") {
+        cleanup();
+        this._renderHexEditor(block);
+        return;
+      }
+
+      if (/^[0-9a-f]$/.test(key)) {
+        this._hexEditBuffer += key;
+        element.textContent = this._hexEditBuffer.padEnd(2, "_");
+
+        if (this._hexEditBuffer.length === 2) {
+          const newVal = parseInt(this._hexEditBuffer, 16);
+          // Map fullData offset back to payload offset (offset 0 = flag, 1..N = payload)
+          const payloadOffset = offset - 1;
+          if (payloadOffset >= 0 && payloadOffset < block.payload.length) {
+            block.payload[payloadOffset] = newVal;
+            // Re-decode header if applicable
+            if (isHeader(block)) {
+              const { headerType, filename, dataLength, param1, param2 } =
+                  await_decodeHeader(block.payload);
+              block.headerType = headerType;
+              block.filename = filename;
+              block.dataLength = dataLength;
+              block.param1 = param1;
+              block.param2 = param2;
+            }
+            // Recompute checksum validity
+            const expected = computeChecksum(block.flag, block.payload);
+            block.checksumValid = block.checksum === expected;
+            this._hexModifiedBytes.add(offset);
+            this._markDirty();
+          }
+          cleanup();
+          this._renderBlocks();
+          this._renderHexEditor(block);
+        }
+      }
+    };
+
+    const cleanup = () => {
+      document.removeEventListener("keydown", onKey, true);
+      this._hexEditingByte = -1;
+      this._hexEditBuffer = "";
+    };
+
+    document.addEventListener("keydown", onKey, true);
+  }
+
+  // ─── File operations ──────────────────────────────────────────
+
+  _newTape() {
+    this._blocks = [];
+    this._currentFilename = null;
+    this._dirty = false;
+    this._selectedBlockIndex = -1;
+    this._hexModifiedBytes.clear();
+    this._updateFilenameDisplay();
+    this._updateDirtyState();
+    this._renderBlocks();
+    this._renderDetail();
+  }
+
+  _openFile() {
+    this._fileInput.click();
+  }
+
+  _loadFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const data = new Uint8Array(reader.result);
+      this._blocks = parseTAP(data);
+      this._currentFilename = file.name;
+      this._dirty = false;
+      this._selectedBlockIndex = -1;
+      this._hexModifiedBytes.clear();
+      this._updateFilenameDisplay();
+      this._updateDirtyState();
+      this._renderBlocks();
+      this._renderDetail();
+      this._showToast(`Loaded ${this._blocks.length} blocks`);
+    };
+    reader.readAsArrayBuffer(file);
+  }
+
+  _saveFile() {
+    if (!this._blocks.length) {
+      this._showToast("Nothing to save");
+      return;
+    }
+
+    const data = assembleTAP(this._blocks);
+    const blob = new Blob([data], { type: "application/octet-stream" });
+    const filename = this._currentFilename || "edited.tap";
+
+    // Try File System Access API first
+    if (window.showSaveFilePicker) {
+      window.showSaveFilePicker({
+        suggestedName: filename,
+        types: [{ description: "TAP files", accept: { "application/octet-stream": [".tap"] } }],
+      }).then(async (handle) => {
+        const writable = await handle.createWritable();
+        await writable.write(blob);
+        await writable.close();
+        this._currentFilename = handle.name;
+        this._dirty = false;
+        this._updateFilenameDisplay();
+        this._updateDirtyState();
+        this._showToast("Saved");
+      }).catch(() => {
+        // User cancelled or API not available
+      });
+    } else {
+      // Fallback: download link
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+      this._dirty = false;
+      this._updateDirtyState();
+      this._showToast("Downloaded");
+    }
+  }
+
+  _mergeFile() {
+    this._mergeFileInput.click();
+  }
+
+  _doMergeFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const data = new Uint8Array(reader.result);
+      const newBlocks = parseTAP(data);
+      if (!newBlocks.length) {
+        this._showToast("No blocks found in file");
+        return;
+      }
+      this._blocks.push(...newBlocks);
+      this._markDirty();
+      this._renderBlocks();
+      this._showToast(`Merged ${newBlocks.length} blocks`);
+    };
+    reader.readAsArrayBuffer(file);
+  }
+
+  _importCurrentTape() {
+    if (!this.tapeWindow || !this.tapeWindow._rawTapeData) {
+      this._showToast("No tape currently loaded in player");
+      return;
+    }
+
+    const data = this.tapeWindow._rawTapeData;
+    const isTZX = this.tapeWindow._isTZX;
+    if (isTZX) {
+      this._showToast("TZX format not supported — TAP only");
+      return;
+    }
+
+    this._blocks = parseTAP(data);
+    this._currentFilename = this.tapeWindow._currentFilename || "imported.tap";
+    this._dirty = false;
+    this._selectedBlockIndex = -1;
+    this._hexModifiedBytes.clear();
+    this._updateFilenameDisplay();
+    this._updateDirtyState();
+    this._renderBlocks();
+    this._renderDetail();
+    this._showToast(`Imported ${this._blocks.length} blocks`);
+  }
+
+  _doImportBinary(file) {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const payload = new Uint8Array(reader.result);
+      const name = (file.name || "binary").replace(/\.[^.]+$/, "").substring(0, 10);
+      const header = createHeaderBlock(HEADER_CODE, name, payload.length, 32768, 32768);
+      const data = createDataBlock(payload);
+
+      // Update header's dataLength to match actual data
+      header.dataLength = payload.length;
+      updateHeaderPayload(header);
+
+      const insertAt = this._selectedBlockIndex >= 0 ? this._selectedBlockIndex + 1 : this._blocks.length;
+      this._blocks.splice(insertAt, 0, header, data);
+      this._markDirty();
+      this._renderBlocks();
+      this._selectBlock(insertAt);
+      this._showToast(`Imported "${name}" (${payload.length} bytes)`);
+    };
+    reader.readAsArrayBuffer(file);
+  }
+
+  _loadIntoEmulator() {
+    if (!this._blocks.length) {
+      this._showToast("No blocks to load");
+      return;
+    }
+
+    const data = assembleTAP(this._blocks);
+    this._proxy.loadTAP(data.buffer);
+    this._showToast("Tape loaded into emulator");
+  }
+
+  _exportBlock(index) {
+    if (index < 0 || index >= this._blocks.length) return;
+    const block = this._blocks[index];
+    const blob = new Blob([block.payload], { type: "application/octet-stream" });
+
+    let filename = `block-${index}`;
+    if (isHeader(block)) {
+      filename = `${block.filename.trim() || "header"}-hdr`;
+    }
+    filename += ".bin";
+
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+    this._showToast(`Exported ${filename}`);
+  }
+
+  _fixAllChecksums() {
+    let fixed = 0;
+    for (const block of this._blocks) {
+      if (!block.checksumValid) {
+        recalcChecksum(block);
+        fixed++;
+      }
+    }
+    if (fixed > 0) {
+      this._markDirty();
+      this._renderBlocks();
+      this._renderDetail();
+      this._showToast(`Fixed ${fixed} checksum${fixed > 1 ? "s" : ""}`);
+    } else {
+      this._showToast("All checksums valid");
+    }
+  }
+
+  // ─── Dirty state tracking ────────────────────────────────────
+
+  _markDirty() {
+    this._dirty = true;
+    this._updateDirtyState();
+  }
+
+  _updateDirtyState() {
+    if (!this._els) return;
+    const saveBtn = this._els.saveBtn;
+    if (saveBtn) {
+      saveBtn.classList.toggle("dirty", this._dirty);
+    }
+  }
+
+  _updateFilenameDisplay() {
+    const banner = this._els.filenameBanner;
+    if (this._currentFilename) {
+      banner.classList.remove("hidden");
+      banner.innerHTML = `<span class="tap-filename-text">${this._escapeHtml(this._currentFilename)}</span>${this._dirty ? '<span class="tap-dirty-indicator">Modified</span>' : ""}`;
+    } else {
+      banner.classList.add("hidden");
+    }
+  }
+
+  // ─── Toast notifications ──────────────────────────────────────
+
+  _showToast(message) {
+    const toast = this._els.toast;
+    toast.textContent = message;
+    toast.classList.add("visible");
+    if (this._toastTimeout) clearTimeout(this._toastTimeout);
+    this._toastTimeout = setTimeout(() => {
+      toast.classList.remove("visible");
+    }, 2000);
+  }
+
+  // ─── Utility ──────────────────────────────────────────────────
+
+  _escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  _escapeAttr(str) {
+    return String(str).replace(/"/g, "&quot;").replace(/&/g, "&amp;");
+  }
+}
+
+/**
+ * Helper to decode header payload inline (avoids import circularity).
+ * Called from hex edit handler.
+ */
+function await_decodeHeader(payload) {
+  if (payload.length !== 17) return {};
+  const headerType = payload[0];
+  let filename = "";
+  for (let i = 1; i <= 10; i++) filename += String.fromCharCode(payload[i]);
+  const dataLength = payload[11] | (payload[12] << 8);
+  const param1 = payload[13] | (payload[14] << 8);
+  const param2 = payload[15] | (payload[16] << 8);
+  return { headerType, filename, dataLength, param1, param2 };
+}

--- a/src/js/tape/tap-parser.js
+++ b/src/js/tape/tap-parser.js
@@ -1,0 +1,270 @@
+/*
+ * tap-parser.js - TAP format parser/assembler utility module
+ *
+ * Pure JavaScript TAP file handling: parse raw bytes into structured blocks,
+ * assemble blocks back into TAP binary format, checksum computation, and
+ * header field encoding/decoding.
+ *
+ * TAP format: repeating [2-byte LE length][flag byte][payload][checksum byte]
+ */
+
+/** Header type constants */
+export const HEADER_PROGRAM = 0;
+export const HEADER_NUM_ARRAY = 1;
+export const HEADER_CHAR_ARRAY = 2;
+export const HEADER_CODE = 3;
+
+/** Flag byte constants */
+export const FLAG_HEADER = 0x00;
+export const FLAG_DATA = 0xff;
+
+/** Header type display names */
+export const HEADER_TYPE_NAMES = ["Program", "Num Array", "Char Array", "Code"];
+
+/**
+ * Compute XOR checksum for flag + payload bytes.
+ * @param {number} flag - Flag byte (0x00 or 0xFF)
+ * @param {Uint8Array} payload - Payload bytes
+ * @returns {number} XOR checksum
+ */
+export function computeChecksum(flag, payload) {
+  let cs = flag;
+  for (let i = 0; i < payload.length; i++) {
+    cs ^= payload[i];
+  }
+  return cs & 0xff;
+}
+
+/**
+ * Decode a 17-byte header payload into its constituent fields.
+ * @param {Uint8Array} payload - 17-byte header payload
+ * @returns {{ headerType: number, filename: string, dataLength: number, param1: number, param2: number }}
+ */
+export function decodeHeaderPayload(payload) {
+  const headerType = payload[0];
+  let filename = "";
+  for (let i = 1; i <= 10; i++) {
+    filename += String.fromCharCode(payload[i]);
+  }
+  const dataLength = payload[11] | (payload[12] << 8);
+  const param1 = payload[13] | (payload[14] << 8);
+  const param2 = payload[15] | (payload[16] << 8);
+  return { headerType, filename, dataLength, param1, param2 };
+}
+
+/**
+ * Encode header fields into a 17-byte payload.
+ * @param {number} headerType - 0=Program, 1=NumArray, 2=CharArray, 3=Code
+ * @param {string} filename - Up to 10 characters (padded with spaces)
+ * @param {number} dataLength - Data length in bytes
+ * @param {number} param1 - Autostart line (Program) or start address (Code)
+ * @param {number} param2 - Variable area offset (Program) or 32768 (Code)
+ * @returns {Uint8Array} 17-byte header payload
+ */
+export function encodeHeaderPayload(headerType, filename, dataLength, param1, param2) {
+  const payload = new Uint8Array(17);
+  payload[0] = headerType & 0xff;
+  // Pad filename to 10 chars with spaces
+  const padded = (filename || "").padEnd(10, " ").substring(0, 10);
+  for (let i = 0; i < 10; i++) {
+    payload[1 + i] = padded.charCodeAt(i) & 0xff;
+  }
+  payload[11] = dataLength & 0xff;
+  payload[12] = (dataLength >> 8) & 0xff;
+  payload[13] = param1 & 0xff;
+  payload[14] = (param1 >> 8) & 0xff;
+  payload[15] = param2 & 0xff;
+  payload[16] = (param2 >> 8) & 0xff;
+  return payload;
+}
+
+/**
+ * Parse raw TAP file bytes into an array of block objects.
+ * @param {Uint8Array} data - Raw TAP file bytes
+ * @returns {Array<Object>} Array of block objects
+ */
+export function parseTAP(data) {
+  const blocks = [];
+  let offset = 0;
+
+  while (offset + 2 <= data.length) {
+    const blockLength = data[offset] | (data[offset + 1] << 8);
+    offset += 2;
+
+    if (blockLength === 0 || offset + blockLength > data.length) {
+      break;
+    }
+
+    const flag = data[offset];
+    const checksum = data[offset + blockLength - 1];
+    const payload = data.slice(offset + 1, offset + blockLength - 1);
+
+    const expectedChecksum = computeChecksum(flag, payload);
+    const checksumValid = checksum === expectedChecksum;
+
+    const block = {
+      flag,
+      payload: new Uint8Array(payload),
+      checksum,
+      checksumValid,
+    };
+
+    // If it's a header block with exactly 17 bytes of payload, decode the header fields
+    if (flag === FLAG_HEADER && payload.length === 17) {
+      const header = decodeHeaderPayload(payload);
+      block.headerType = header.headerType;
+      block.filename = header.filename;
+      block.dataLength = header.dataLength;
+      block.param1 = header.param1;
+      block.param2 = header.param2;
+    }
+
+    blocks.push(block);
+    offset += blockLength;
+  }
+
+  return blocks;
+}
+
+/**
+ * Assemble an array of block objects back into raw TAP file bytes.
+ * @param {Array<Object>} blocks - Array of block objects
+ * @returns {Uint8Array} Raw TAP file bytes
+ */
+export function assembleTAP(blocks) {
+  // Calculate total size: 2 bytes length + flag + payload + checksum per block
+  let totalSize = 0;
+  for (const block of blocks) {
+    totalSize += 2 + 1 + block.payload.length + 1; // length word + flag + payload + checksum
+  }
+
+  const result = new Uint8Array(totalSize);
+  let offset = 0;
+
+  for (const block of blocks) {
+    const blockDataLength = 1 + block.payload.length + 1; // flag + payload + checksum
+
+    // 2-byte LE length
+    result[offset] = blockDataLength & 0xff;
+    result[offset + 1] = (blockDataLength >> 8) & 0xff;
+    offset += 2;
+
+    // Flag byte
+    result[offset] = block.flag;
+    offset += 1;
+
+    // Payload
+    result.set(block.payload, offset);
+    offset += block.payload.length;
+
+    // Checksum
+    result[offset] = block.checksum;
+    offset += 1;
+  }
+
+  return result;
+}
+
+/**
+ * Recalculate and fix the checksum for a block.
+ * @param {Object} block - Block object to fix
+ */
+export function recalcChecksum(block) {
+  block.checksum = computeChecksum(block.flag, block.payload);
+  block.checksumValid = true;
+}
+
+/**
+ * Update a header block's payload from its decoded fields.
+ * Call this after modifying headerType, filename, dataLength, param1, or param2.
+ * @param {Object} block - Header block to update
+ */
+export function updateHeaderPayload(block) {
+  if (block.flag !== FLAG_HEADER || block.payload.length !== 17) return;
+  block.payload = encodeHeaderPayload(
+    block.headerType,
+    block.filename,
+    block.dataLength,
+    block.param1,
+    block.param2,
+  );
+  recalcChecksum(block);
+}
+
+/**
+ * Create a new header block with sensible defaults.
+ * @param {number} headerType - 0=Program, 1=NumArray, 2=CharArray, 3=Code
+ * @param {string} filename - Up to 10 characters
+ * @param {number} dataLength - Data length in bytes
+ * @param {number} [param1=0] - Autostart line or start address
+ * @param {number} [param2=32768] - Variable offset or 32768
+ * @returns {Object} New header block
+ */
+export function createHeaderBlock(headerType, filename, dataLength, param1 = 0, param2 = 32768) {
+  const payload = encodeHeaderPayload(headerType, filename, dataLength, param1, param2);
+  const flag = FLAG_HEADER;
+  const checksum = computeChecksum(flag, payload);
+
+  return {
+    flag,
+    payload,
+    checksum,
+    checksumValid: true,
+    headerType,
+    filename: (filename || "").padEnd(10, " ").substring(0, 10),
+    dataLength,
+    param1,
+    param2,
+  };
+}
+
+/**
+ * Create a new data block from payload bytes.
+ * @param {Uint8Array} payload - Data payload bytes
+ * @returns {Object} New data block
+ */
+export function createDataBlock(payload) {
+  const flag = FLAG_DATA;
+  const p = new Uint8Array(payload);
+  const checksum = computeChecksum(flag, p);
+
+  return {
+    flag,
+    payload: p,
+    checksum,
+    checksumValid: true,
+  };
+}
+
+/**
+ * Check if a block is a header block with decoded fields.
+ * @param {Object} block
+ * @returns {boolean}
+ */
+export function isHeader(block) {
+  return block.flag === FLAG_HEADER && block.payload.length === 17;
+}
+
+/**
+ * Get a human-readable description of a block.
+ * @param {Object} block
+ * @param {number} index - Block index in the list
+ * @returns {{ badge: string, name: string, size: string, typeName: string }}
+ */
+export function describeBlock(block) {
+  if (isHeader(block)) {
+    const typeName = HEADER_TYPE_NAMES[block.headerType] || "Unknown";
+    return {
+      badge: "HDR",
+      name: `${typeName}: "${block.filename}"`,
+      size: `${block.dataLength}b`,
+      typeName,
+    };
+  }
+  return {
+    badge: "DATA",
+    name: "",
+    size: `${block.payload.length}b`,
+    typeName: "Data",
+  };
+}


### PR DESCRIPTION
## Summary
- New **TAP Editor** window accessible from View menu for full editing of TAP tape image files
- Pure JavaScript TAP format parser/assembler (`tap-parser.js`) with checksum computation and header field encoding/decoding
- Block list with drag-and-drop reordering, move up/down buttons, and visual header+data pair grouping
- Header field editing (filename, type, autostart line/start address, params) with live checksum validation
- Hex viewer/editor with virtualized scrolling for large blocks, click-to-edit bytes, and ASCII column
- Block creation (add header+data pairs), deletion (with pair-aware confirmation), and binary file import as Code blocks
- Merge blocks from other TAP files, export individual blocks, fix all checksums
- Save edited TAP to disk and load directly into the running emulator
- Themed CSS using only CSS custom properties — works in both dark and light modes

## Test plan
- [ ] Open TAP Editor from View menu — verify window appears with toolbar, empty block list, detail panel
- [ ] Click "Add Block Pair" — verify form appears, create a Code block, verify it shows in the list with HDR/DATA badges
- [ ] Select a header block — verify Header tab shows editable fields (filename, type, params, checksum status)
- [ ] Switch to Hex tab — verify hex dump displays flag byte, payload, and checksum with ASCII column
- [ ] Test move up/down and drag-and-drop reordering
- [ ] Test block deletion with pair confirmation dialog
- [ ] Open a .tap file — verify all blocks parse and display correctly
- [ ] Edit header filename and type — verify block list updates and Save button shows dirty state
- [ ] Click "Load into Emu" — verify tape loads in the emulator's tape player
- [ ] Click "Save" — verify .tap file downloads/saves correctly
- [ ] Test in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)